### PR TITLE
Return data as StreamInterface on get() call

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -42,16 +42,16 @@ class Client
 
     /**
      * @param string $idWithCommand
-     * @return string Binary data
+     * @return StreamInterface Binary data stream
      * @throws Exception
      */
-    public function get(string $idWithCommand): string
+    public function get(string $idWithCommand): StreamInterface
     {
         return $this->handleExceptions(function () use ($idWithCommand) {
             $response = $this->httpClient->get($idWithCommand, ['timeout' => $this->connectionTimeout]);
 
             if ($response->getStatusCode() === 200) {
-                return (string) $response->getBody();
+                return $response->getBody();
             }
 
             throw new Exception(

--- a/tests/integration/GetTest.php
+++ b/tests/integration/GetTest.php
@@ -5,6 +5,7 @@ namespace Barberry\IntegrationTests;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp;
 use Barberry;
+use Psr\Http\Message\StreamInterface;
 
 class GetTest extends TestCase
 {
@@ -30,6 +31,13 @@ class GetTest extends TestCase
         $id = self::uploadImage(__DIR__ . '/data/image.jpg');
 
         self::assertStringEqualsFile(__DIR__ . '/data/image.jpg', $this->client->get($id));
+    }
+
+    public function testReturnStreamOfBinaryData(): void
+    {
+        $id = self::uploadImage(__DIR__ . '/data/image.jpg');
+
+        self::assertInstanceOf(StreamInterface::class, $this->client->get($id));
     }
 
     public function testUnavailableService(): void


### PR DESCRIPTION
@Magomogo I've found that we use also `Client::get()` in our components to read big files (I've skipped this previously), let's also return `StreamInterface` to work with it in memory safe way.